### PR TITLE
Remove forced export_all as test compile options

### DIFF
--- a/src/main/java/eu/lindenbaum/maven/mojo/app/TestCompiler.java
+++ b/src/main/java/eu/lindenbaum/maven/mojo/app/TestCompiler.java
@@ -23,7 +23,7 @@ import org.apache.maven.plugin.logging.Log;
 
 /**
  * Compile erlang test sources and recompile erlang sources with the options
- * {@code debug_info}, {@code export_all} and <code>{d, 'TEST'}</code>. This
+ * {@code debug_info} and <code>{d, 'TEST'}</code>. This
  * will also compile the supporting erlang sources provided along with the
  * plugin.
  * 
@@ -106,7 +106,6 @@ public final class TestCompiler extends ErlangMojo {
 
       List<String> options = new ArrayList<String>();
       options.add("debug_info");
-      options.add("export_all");
       options.add("{d, 'TEST'}");
       if (this.testCompilerOptions != null && !this.testCompilerOptions.isEmpty()) {
         log.info("Using additinal test compiler options: " + this.testCompilerOptions);


### PR DESCRIPTION
export_all compile option should not be forced even for test compilation. It can cause problems for example during proper (https://github.com/manopapad/proper) test run.
